### PR TITLE
Add SET_PRODUCT_QUERY action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `SET_PRODUCT_QUERY` action
 
 ## [0.2.0] - 2019-08-27
 ### Added
@@ -13,7 +15,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `selectedItem` and `selectedQuantity` to context state
 
 ## [0.1.0] - 2019-07-02
-
 ### Added
-
 - Initial release.

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -10,6 +10,7 @@ interface State {
   isLoading: boolean
   selectedItem: any,
   selectedQuantity: number,
+  productQuery?: string,
 }
 
 type Dispatch = (action: Action) => void
@@ -18,6 +19,13 @@ type SetProductAction = {
   type: 'SET_PRODUCT',
   args: {
     product: any
+  }
+}
+
+type SetProductQueryAction = {
+  type: 'SET_PRODUCT_QUERY',
+  args: {
+    query: string
   }
 }
 
@@ -42,7 +50,7 @@ type SetProductQuantity = {
   }
 }
 
-type Action = SetProductAction | SetHoverAction | SetLoadingAction | SetProductQuantity
+type Action = SetProductAction | SetHoverAction | SetLoadingAction | SetProductQuantity | SetProductQueryAction
 
 export function reducer(state: State, action: Action) {
   switch (action.type) {
@@ -73,6 +81,11 @@ export function reducer(state: State, action: Action) {
         selectedQuantity: action.args.quantity,
       }
     }
+    case 'SET_PRODUCT_QUERY':
+      return {
+        ...state,
+        query: action.args.query,
+      }
     default:
       return state
   }


### PR DESCRIPTION
### Added

- `SET_PRODUCT_QUERY` to help the `SKUSelector` in `ProductSummary`  to work, with this action now you can select an SKU at `ProductSummary` and click on Summary, you will go to the product page with the SKU selected.

[workspace](https://skuinsummary--storecomponents.myvtex.com/classic?_q=classic&map=ft)

#### Extra information

- There is a bug at summary, if open the workspace you will see that the first SKU color is selected, but if you click on summary you will go to product's but no sku is selected, this will be fixed in the responsible repository.