### PR TITLE
add selectedProperties query string to the product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `property__VariationName=VariationValue` query string to the product query.
+
 ## [0.3.0] - 2019-10-15
 ### Added
 - `SET_PRODUCT_QUERY` action

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -1,14 +1,16 @@
 import React, { useReducer } from 'react'
 import { createContext, useContext } from 'react'
+import querystring from 'query-string'
+import { Product, SKU } from './typings/product'
 
 const ProductSummaryContext = createContext<State | undefined>(undefined)
 const ProductDispatchContext = createContext<Dispatch | undefined>(undefined)
 
 interface State {
-  product: any
+  product: Product
   isHovering: boolean
   isLoading: boolean
-  selectedItem: any,
+  selectedItem: SKU,
   selectedQuantity: number,
   productQuery?: string,
 }
@@ -18,7 +20,7 @@ type Dispatch = (action: Action) => void
 type SetProductAction = {
   type: 'SET_PRODUCT',
   args: {
-    product: any
+    product: Product
   }
 }
 
@@ -91,6 +93,23 @@ export function reducer(state: State, action: Action) {
   }
 }
 
+const buildProductQuery = ((product: Product) => {
+  const selectedProperties = product.selectedProperties
+
+  if (!selectedProperties) {
+    return
+  }
+
+  const query = {}
+
+  selectedProperties.forEach(property => {
+    const {key, value} = property
+    query[`property__${key}`] = value
+  })
+
+  return querystring.stringify(query)
+})
+
 function ProductSummaryProvider({ product, children }) {
   const initialState = {
     product,
@@ -98,6 +117,7 @@ function ProductSummaryProvider({ product, children }) {
     isLoading: false,
     selectedItem: null,
     selectedQuantity: 1,
+    query: buildProductQuery(product)
   }
 
   const [state, dispatch] = useReducer(reducer, initialState)

--- a/react/package.json
+++ b/react/package.json
@@ -1,9 +1,11 @@
 {
   "devDependencies": {
     "@types/node": "^11.13.4",
+    "@types/query-string": "5",
     "@types/react": "^16.8.13"
   },
   "dependencies": {
+    "query-string": "5",
     "ramda": "^0.26.1"
   },
   "version": "0.3.0"

--- a/react/typings/product.d.ts
+++ b/react/typings/product.d.ts
@@ -1,0 +1,62 @@
+export interface Product {
+  linkText: string
+  productName: string
+  brand: string
+  categoryId: string
+  categoryTree: Category[]
+  productId: string
+  titleTag: string
+  metaTagDescription: string
+  items: SKU[]
+  skuSpecifications: SkuSpecification[]
+  selectedProperties: SelectedProperty[]
+  sku: SKU
+}
+
+interface Category {
+  id: string
+  name: string
+}
+
+export interface SKU {
+  itemId: string
+  ean: string
+  referenceId: [{ Value: string }]
+  sellers: Seller[]
+}
+
+interface Seller {
+  commertialOffer: CommertialOffer
+  sellerId: string
+}
+
+interface CommertialOffer {
+  ListPrice: number
+  Price: number
+}
+
+interface Seller {
+  commertialOffer: CommertialOffer
+}
+
+interface CommertialOffer {
+  AvailableQuantity: number
+}
+
+interface SkuSpecification {
+  field: SkuSpecificationField
+  values: SkuSpecificationValues[]
+}
+
+interface SkuSpecificationField {
+  name: string
+}
+
+interface SkuSpecificationValues {
+  name: string
+}
+
+interface SelectedProperty {
+  key: string;
+  value: string
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
   integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
 
+"@types/query-string@5":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/query-string/-/query-string-5.1.0.tgz#7f40cdea49ddafa0ea4f3db35fb6c24d3bfd4dcc"
+  integrity sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg==
+
 "@types/react@^16.8.13":
   version "16.8.13"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.13.tgz#a82b15aad9ab91c40edca0d6889b7745ae24f053"
@@ -25,7 +30,31 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.4.tgz#d585a6062096e324e7187f80e04f92bd0f00e37f"
   integrity sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg==
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+query-string@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=


### PR DESCRIPTION
#### What problem is this solving?

The intelligent search has a feature called split. Basically, instead of showing one product with three possible colors, we show three products, each one with one color.

Before split:
![image](https://user-images.githubusercontent.com/40380674/86956776-06821200-c130-11ea-8534-8824f1c2bd1e.png)
After split:
![image](https://user-images.githubusercontent.com/40380674/86956818-1863b500-c130-11ea-98b5-639ebb4aeaf3.png)

The problem is: when you click in one of those split products, the variation selected in the PLP will not be the one selected in the PDP.

To fix this, we decided to use a query string with this format: `?property__variationName=variationValue`. This way, we can select the variation by using a query string.

For example:

 - [Color pink](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Pink): `?property__Color=Pink`
- [Color black](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Black): `?property__Color=Black`
- [Color camel](https://hiago--footnotes.myvtex.com/luna-snake-flat-slingback-275central-lunasling/p?property__Color=Camel): `?property__Color=Camel`

With this PR, the `product-summary-context` will add those query string to the product link.
#### How to test it?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

Click in any of the products. See that the query strings are in the URL.