### PR TITLE
Add selectedItem prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `selectedItem` prop to `ProductSummaryProvider`
+
 ## [0.4.0] - 2020-07-10
 
 ### Added

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -21,6 +21,7 @@ type SetProductAction = {
   type: 'SET_PRODUCT',
   args: {
     product: Product
+    selectedItem: SKU
   }
 }
 
@@ -62,7 +63,7 @@ export function reducer(state: State, action: Action) {
         ...state,
         product: product,
         //TODO: STOP USING PRODUCT.SKU https://app.clubhouse.io/vtex/story/18547/productsummarycontext-refactor
-        selectedItem: product.sku
+        selectedItem: action.args.selectedItem ?? product.sku
       }
     }
     case 'SET_HOVER': {
@@ -110,12 +111,12 @@ const buildProductQuery = ((product: Product) => {
   return querystring.stringify(query)
 })
 
-function ProductSummaryProvider({ product, children }) {
+function ProductSummaryProvider({ product, selectedItem, children }) {
   const initialState = {
     product,
     isHovering: false,
     isLoading: false,
-    selectedItem: null,
+    selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
     query: buildProductQuery(product)
   }


### PR DESCRIPTION
Currently, the `ProductSummaryProvider` receives the product info, but not the selected item. therefore, it is not possible to pass an specific item to `ProductSummary` and it only displays the product information.
With the `Buy Together` shelf, we want to make it possible for the user to buy specific products directly from the shelf, for this we need the information of the `selectedItem`.

[Without selectedItem](https://thalyta1--storecomponents.myvtex.com/blouse-with-knot/p?skuId=2000543)

[With selectedItem](https://selecteditem--storecomponents.myvtex.com/blouse-with-knot/p?skuId=2000544)

_To test, change the color of the product and see if the ProductSummary on the shelf will also change._