### PR TITLE
Add ProductGroupContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Send `product` and `selectedItem` to `ProductGroupContext`.
+
 ## [0.4.2] - 2020-07-20
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,9 @@
   "title": "VTEX Product Summary Context",
   "description": "",
   "settingsSchema": {},
-  "dependencies": {},
+  "dependencies": {
+    "vtex.product-group-context": "0.x"
+  },
   "builders": {
     "react": "3.x",
     "docs": "0.x"

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -1,7 +1,11 @@
-import React, { useReducer } from 'react'
+import React, { useReducer, useEffect } from 'react'
 import { createContext, useContext } from 'react'
 import querystring from 'query-string'
+import { ProductGroupContext } from 'vtex.product-group-context'
+
 import { Product, SKU } from './typings/product'
+
+const { useProductGroup } = ProductGroupContext
 
 const ProductSummaryContext = createContext<State | undefined>(undefined)
 const ProductDispatchContext = createContext<Dispatch | undefined>(undefined)
@@ -122,6 +126,19 @@ function ProductSummaryProvider({ product, selectedItem, children }) {
   }
 
   const [state, dispatch] = useReducer(reducer, initialState)
+
+  const productGroupContext = useProductGroup()
+
+  useEffect(() => {
+    if (!productGroupContext) {
+      return
+    }
+
+    const { addItemToGroup } = productGroupContext
+    const removeItemFromGroup = addItemToGroup(state.product, state.selectedItem ?? state.product.items[0])
+
+    return () => removeItemFromGroup()
+  }, [state.selectedItem, state.product])
 
   return (
     <ProductSummaryContext.Provider value={state}>

--- a/react/package.json
+++ b/react/package.json
@@ -2,7 +2,9 @@
   "devDependencies": {
     "@types/node": "^11.13.4",
     "@types/query-string": "5",
-    "@types/react": "^16.8.13"
+    "@types/react": "^16.8.13",
+    "vtex.product-group-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-group-context@0.1.0/public/@types/vtex.product-group-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime"
   },
   "dependencies": {
     "query-string": "5",

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "esnext",
     "jsx": "react",
     "lib": ["dom", "es7"],
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "lib": ["dom", "es7"]
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -58,3 +58,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+"vtex.product-group-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-group-context@0.1.0/public/@types/vtex.product-group-context":
+  version "0.1.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-group-context@0.1.0/public/@types/vtex.product-group-context#1117d509c8374813b947756c56cf6277e95ad773"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime":
+  version "8.111.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime#01b2ce53d1aa2a974f5229c61bd9c83b43a86d76"


### PR DESCRIPTION
Currently, the information about `product` and `selectedItem` is only in the `ProductSummaryContext`, because we always used this information in the `ProductSummary`. 
However, now we need to have this information in a Context external to the `ProductSummary`, this is because at Shelf `BuyTogether` we need to deal with several different products to add them all to the cart with a single click on a button that is outside the `ProductSummary`. That way, we need to send `product` and `selectedItem` to the `ProductGroupContext` to get the products and items selected in the Shelf easier.

Testing:

- [Workspace](https://thalyta3--storecomponents.myvtex.com/blouse-with-knot/p)
- Click the add to cart button of BuyTogether shelf