### PR TITLE
add optional chaining when accessing the selectedProperties field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Deal with `undefined` products when accessing the `selectedProperties` field.
+
 ## [0.4.1] - 2020-07-13
 
 ### Added

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -95,7 +95,7 @@ export function reducer(state: State, action: Action) {
 }
 
 const buildProductQuery = ((product: Product) => {
-  const selectedProperties = product.selectedProperties
+  const selectedProperties = product?.selectedProperties
 
   if (!selectedProperties) {
     return


### PR DESCRIPTION
#### What problem is this solving?

Deal with `undefined` products when accessing the `selectedProperties` field.

#### How to test it?

[Workspace](https://hiago--iocea.myvtex.com/search?_query=mouse)