### PR TITLE
split property__VariationName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Split the `property__VariationName` query string into `propertyName` and `propertyValue`.
+
 ## [0.4.2] - 2020-07-20
 
 ### Fixed

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -97,16 +97,20 @@ export function reducer(state: State, action: Action) {
 const buildProductQuery = ((product: Product) => {
   const selectedProperties = product?.selectedProperties
 
-  if (!selectedProperties) {
+  if (!selectedProperties || selectedProperties.length === 0) {
     return
   }
 
-  const query = {}
+  const query = selectedProperties.reduce(
+    (query, property, idx) => {
+      const { key, value } = property
+      query.propertyName += `${idx > 0 ? "," : ""}${key}`
+      query.propertyValue += `${idx > 0 ? "," : ""}${value}`
 
-  selectedProperties.forEach(property => {
-    const {key, value} = property
-    query[`property__${key}`] = value
-  })
+      return query
+    },
+    { propertyName: "", propertyValue: "" }
+  )
 
   return querystring.stringify(query)
 })


### PR DESCRIPTION
#### What problem is this solving?

In the https://github.com/vtex-apps/product-summary-context/pull/9 we introduced a new query string: the `property__VariationName: VariationValue`. Unfortunately, this query string [can't be added to the cache whitelist](https://github.com/vtex/reliability/issues/2053#issuecomment-662417601) since it is a regex.

This PR splits the `property__` query string into two new ones: `propertyName` and `propertyValye`

##### Example:
Before PR: `?porperty__Color=Blue&property__Size=G`
After PR: `?porpertyName=Color,Size&propertyValue=Blue,G` 

Feel free to suggest me any other query string format ✌️ 

#### How to test it?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

Click in any of the products. See that the variation in PDP is pre-selected.

#### Related to / Depends on
- https://github.com/vtex-apps/product-context/pull/31