### PR TITLE
add isPriceLoading to the ProductSummaryContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `isPriceLoading` to the `ProductSummary` context.
 
 ## [0.5.0] - 2020-09-21
 ### Added

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -201,7 +201,6 @@ function useProductSummary() {
 }
 
 export default {
-  ProductSummaryConsumer: ProductSummaryContext.Consumer,
   ProductSummaryProvider,
   useProductSummary,
   useProductSummaryDispatch,

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -14,6 +14,7 @@ interface State {
   product: Product
   isHovering: boolean
   isLoading: boolean
+  isPriceLoading: boolean
   selectedItem: SKU,
   selectedQuantity: number,
   inView: boolean
@@ -51,6 +52,13 @@ type SetLoadingAction = {
   }
 }
 
+type SetPriceLoadingAction = {
+  type: 'SET_PRICE_LOADING'
+  args: {
+    isPriceLoading: boolean
+  }
+}
+
 type SetProductQuantity = {
   type: 'SET_QUANTITY'
   args: {
@@ -69,6 +77,7 @@ type Action =
   | SetProductAction
   | SetHoverAction
   | SetLoadingAction
+  | SetPriceLoadingAction
   | SetProductQuantity
   | SetProductQueryAction
   | SetInView
@@ -94,6 +103,12 @@ export function reducer(state: State, action: Action) {
       return {
         ...state,
         isLoading: action.args.isLoading
+      }
+    }
+    case 'SET_PRICE_LOADING': {
+      return {
+        ...state,
+        isPriceLoading: action.args.isPriceLoading,
       }
     }
     case 'SET_QUANTITY': {
@@ -135,11 +150,18 @@ const buildProductQuery = ((product: Product) => {
   return querystring.stringify(query)
 })
 
-function ProductSummaryProvider({ product, selectedItem, isLoading=false, children }) {
+function ProductSummaryProvider({
+  product,
+  selectedItem,
+  isLoading = false,
+  isPriceLoading = false,
+  children,
+}) {
   const initialState = {
     product,
     isHovering: false,
     isLoading,
+    isPriceLoading,
     selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
     query: buildProductQuery(product),
@@ -179,6 +201,7 @@ function useProductSummary() {
 }
 
 export default {
+  ProductSummaryConsumer: ProductSummaryContext.Consumer,
   ProductSummaryProvider,
   useProductSummary,
   useProductSummaryDispatch,


### PR DESCRIPTION
#### What problem is this solving?

Add the `isPriceLoading` field to the `ProductSummaryContext`. It's useful when the async price is set

![mg9CV9NmH7](https://user-images.githubusercontent.com/40380674/95601480-e5300b00-0a29-11eb-8962-775db86d7938.gif)

#### How to test it?

[Workspace](https://hiago--storecomponents.myvtex.com/top?_q=top&map=ft)
