### PR TITLE
Adding listName to querystring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `listName` to querystring to track from which product list the user came from
 
 ## [0.7.1] - 2021-04-29
 ### Fixed

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -122,7 +122,12 @@ export function reducer(state: State, action: Action): State {
   }
 }
 
-const buildProductQuery = ((product: Product, listName?: string) => {
+interface BuildProductQueryParams {
+  product: Product
+  listName?: string
+}
+
+const buildProductQuery = (({ product, listName }: BuildProductQueryParams) => {
   const selectedProperties = product?.selectedProperties
 
   if (!selectedProperties && !listName) {
@@ -162,7 +167,7 @@ function ProductSummaryProvider({
     isPriceLoading,
     selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
-    query: buildProductQuery(product, listName),
+    query: buildProductQuery({ product, listName }),
     inView: false,
   }
 

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -122,16 +122,16 @@ export function reducer(state: State, action: Action): State {
   }
 }
 
-const buildProductQuery = ((product: Product) => {
+const buildProductQuery = ((product: Product, listName?: string) => {
   const selectedProperties = product?.selectedProperties
 
-  if (!selectedProperties) {
+  if (!selectedProperties && !listName) {
     return
   }
 
-  const query = {}
+  const query = { listName: listName ? encodeURIComponent(listName) : undefined }
 
-  selectedProperties.forEach(property => {
+  selectedProperties?.forEach(property => {
     const {key, value} = property
     query[`property__${key}`] = value
   })
@@ -144,6 +144,7 @@ interface ProviderProps {
   selectedItem?: SingleSKU
   isLoading?: boolean
   isPriceLoading?: boolean
+  listName?: string
 }
 
 function ProductSummaryProvider({
@@ -151,6 +152,7 @@ function ProductSummaryProvider({
   selectedItem,
   isLoading = false,
   isPriceLoading = false,
+  listName = null,
   children,
 }: PropsWithChildren<ProviderProps>) {
   const initialState = {
@@ -160,7 +162,7 @@ function ProductSummaryProvider({
     isPriceLoading,
     selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
-    query: buildProductQuery(product),
+    query: buildProductQuery(product, listName),
     inView: false,
   }
 


### PR DESCRIPTION
This PR adds listName to the querystring so when users click on the product, the product page can send (via the `productView` event) from where the user came from.

[Workspace for testing](https://icarogtm--storecomponents.myvtex.com/)

![](https://media.giphy.com/media/bcbPzkSCytDH2/giphy.gif)