### PR TITLE
Moving listName to the state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `listName` to state properties and removed from querystring
 
 ## [0.8.0] - 2021-06-08
 ### Added

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -124,19 +124,18 @@ export function reducer(state: State, action: Action): State {
 
 interface BuildProductQueryParams {
   product: Product
-  listName?: string
 }
 
-const buildProductQuery = (({ product, listName }: BuildProductQueryParams) => {
+const buildProductQuery = (({ product }: BuildProductQueryParams) => {
   const selectedProperties = product?.selectedProperties
 
-  if (!selectedProperties && !listName) {
+  if (!selectedProperties) {
     return
   }
 
-  const query = { listName: listName ? encodeURIComponent(listName) : undefined }
+  const query = {}
 
-  selectedProperties?.forEach(property => {
+  selectedProperties.forEach(property => {
     const {key, value} = property
     query[`property__${key}`] = value
   })
@@ -167,7 +166,8 @@ function ProductSummaryProvider({
     isPriceLoading,
     selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
-    query: buildProductQuery({ product, listName }),
+    listName,
+    query: buildProductQuery({ product }),
     inView: false,
   }
 

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -7,6 +7,7 @@ export interface State {
   selectedQuantity: number,
   inView: boolean
   productQuery?: string
+  listName?: string
   query?: string
 }
 


### PR DESCRIPTION
This PR moves `listName` to the state and removes it from the querystring. It was affecting the behavior of some marketing campaigns when it was on the URL. Putting it on the state allows Product Summary to send it via runtime params, which are invisible to the user and are more appropriate for this use case.

For more info, take a look at [https://github.com/vtex-apps/product-summary/pull/318](https://github.com/vtex-apps/product-summary/pull/318)