### PR TITLE
add productReference type on Product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `productReference` prop to `Product`
+- `productReference` property to `Product`
 
 ## [0.8.1] - 2021-06-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `productReference` prop to `Product`
+
 ## [0.8.1] - 2021-06-28
 ### Changed
 - `listName` to state properties and removed from querystring

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -23,7 +23,7 @@ export interface Product {
   priceRange: PriceRangeOptions;
   productName: string;
   productId: string;
-  productReference: string;
+  productReference?: string;
   productClusters: Array<{name: string;}>;
   selectedProperties: SelectedProperty[];
   skuSpecifications: SkuSpecification[];

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -12,22 +12,25 @@ export interface State {
 }
 
 export interface Product {
-  linkText: string
-  description: string
-  productName: string
-  brand: string
-  brandId: number
-  categoryId: string
-  categoryTree: Category[]
-  productId: string
-  titleTag: string
-  metaTagDescription: string
-  items: SKU[]
-  skuSpecifications: SkuSpecification[]
-  selectedProperties: SelectedProperty[]
-  productClusters: Array<{ name: string }>
-  priceRange: PriceRangeOptions
-  sku: SingleSKU
+  brand: string;
+  brandId: number;
+  categoryId: string;
+  categoryTree: Category[];
+  description: string;
+  items: SKU[];
+  linkText: string;
+  metaTagDescription: string;
+  priceRange: PriceRangeOptions;
+  productName: string;
+  productId: string;
+  productReference: string;
+  productClusters: Array<{
+      name: string;
+  }>;
+  selectedProperties: SelectedProperty[];
+  skuSpecifications: SkuSpecification[];
+  sku: SingleSKU;
+  titleTag: string;
 }
 
 interface Image {

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -24,9 +24,7 @@ export interface Product {
   productName: string;
   productId: string;
   productReference: string;
-  productClusters: Array<{
-      name: string;
-  }>;
+  productClusters: Array<{name: string;}>;
   selectedProperties: SelectedProperty[];
   skuSpecifications: SkuSpecification[];
   sku: SingleSKU;


### PR DESCRIPTION
# Overview

This PR is to add **productReference** type on **Product** and sort alphabetical  types 

## Workspace

Example with a block of product-summary 

- https://reference--idville.myvtex.com/

## Evidence

![image](https://user-images.githubusercontent.com/33559104/126627173-1f7409da-f402-4834-bd9b-76a0933ae77f.png)
