### PR TITLE
Add Set Position Action to Product Summary Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `position` action to product summary context
+
 ## [0.10.0] - 2023-09-27
 
 ## [0.9.0] - 2021-09-06

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -62,6 +62,13 @@ type SetInView = {
   }
 }
 
+type SetPosition = {
+  type: 'SET_POSITION'
+  args: {
+    position: number
+  }
+}
+
 type Action =
   | SetProductAction
   | SetHoverAction
@@ -70,6 +77,7 @@ type Action =
   | SetProductQuantity
   | SetProductQueryAction
   | SetInView
+  | SetPosition
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -115,6 +123,11 @@ export function reducer(state: State, action: Action): State {
       return {
         ...state,
         inView: action.args.inView,
+      }
+    case 'SET_POSITION':
+      return {
+        ...state,
+        position: action.args.position,
       }
 
     default:
@@ -169,6 +182,7 @@ function ProductSummaryProvider({
     listName,
     query: buildProductQuery({ product }),
     inView: false,
+    position: null,
   }
 
   const [state, dispatch] = useReducer(reducer, initialState)

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -9,6 +9,7 @@ export interface State {
   productQuery?: string
   listName?: string
   query?: string
+  position?: number
 }
 
 export interface Product {


### PR DESCRIPTION
#### What problem is this solving?

Add Set Position Action to Product Summary Context in order to let other components within the context to use the position order of the Product Summary inside search result or list context.

#### How to test it?

Whirlpool Poland: https://www.whirlpool.pl/urzadzenia/pranie/pralki?workspace=fetchpriorityplp

Whirlpool France: https://www.whirlpool.fr/produits/lavage/lave-linge?workspace=fetchpriorityplp

Whirlpool Italy: https://www.whirlpool.it/prodotti/lavaggio-e-asciugatura/lavatrici?workspace=fetchpriorityplp

Hotpoint Italy: https://www.hotpoint.it/elettrodomestici/lavaggio-e-asciugatura/lavatrici?workspace=fetchpriorityplp

Bauknecht Germany: https://www.bauknecht.de/hausgeraete/waschen-trocknen/waschmaschinen?workspace=fetchpriorityplp

Hotpoint UK: https://www.hotpoint.co.uk/appliances/laundry/washing-machines?workspace=fetchpriorityplp

