### PR TITLE
Feature: add sponsored badge position option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the argument `sponsoredBadgeOptions` to `ProductSummaryProvider`.
+
 ## [0.10.0] - 2023-09-27
 
 ## [0.9.0] - 2021-09-06

--- a/react/ProductSummaryContext.tsx
+++ b/react/ProductSummaryContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react'
 import querystring from 'query-string'
 import { ProductGroupContext } from 'vtex.product-group-context'
 
-import { Product, SingleSKU, SKU, State } from './ProductSummaryTypes'
+import { Product, SingleSKU, SKU, SponsoredBadgeOptions, State } from './ProductSummaryTypes'
 
 const { useProductGroup } = ProductGroupContext
 
@@ -149,6 +149,7 @@ interface ProviderProps {
   isLoading?: boolean
   isPriceLoading?: boolean
   listName?: string
+  sponsoredBadge?: SponsoredBadgeOptions
 }
 
 function ProductSummaryProvider({
@@ -157,6 +158,7 @@ function ProductSummaryProvider({
   isLoading = false,
   isPriceLoading = false,
   listName = null,
+  sponsoredBadge = {},
   children,
 }: PropsWithChildren<ProviderProps>) {
   const initialState = {
@@ -167,6 +169,7 @@ function ProductSummaryProvider({
     selectedItem: selectedItem ?? null,
     selectedQuantity: 1,
     listName,
+    sponsoredBadge,
     query: buildProductQuery({ product }),
     inView: false,
   }

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -9,6 +9,7 @@ export interface State {
   productQuery?: string
   listName?: string
   query?: string
+  sponsoredBadge?: SponsoredBadgeOptions
 }
 
 export interface Product {
@@ -116,3 +117,10 @@ interface SelectedProperty {
   key: string;
   value: string
 }
+
+export type SponsoredBadgeOptions = {
+  label?: string;
+  position?: SponsoredBadgePosition
+}
+
+export type SponsoredBadgePosition = "titleTop" | "containerTopLeft" | "none";


### PR DESCRIPTION
### Description

In some stores, the layout doesn't work so well with the sponsored tag begin on top of the product's name.

This PR adds the value `sponsoredBadgeOptions` to `useProductSummary()` so that the values of `position` passed via props to `<ProductSummary />` can be used in multiple locations.