### PR TITLE
feat: add SkuNonStructuredAttribute and attributes field to SKU inter…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `SkuNonStructuredAttribute` interface and optional `attributes` field on the `SKU` interface to expose non-structured SKU specifications coming from `vtex.search-graphql`.
+
 ## [0.13.0] - 2025-07-17
 
 ### Added

--- a/react/ProductSummaryTypes.ts
+++ b/react/ProductSummaryTypes.ts
@@ -59,6 +59,13 @@ interface Image {
   imageUrl: string
 }
 
+export interface SkuNonStructuredAttribute {
+  id: string
+  name: string
+  value: string
+  visible: boolean
+}
+
 export interface SKU {
   name: string
   itemId: string
@@ -66,6 +73,7 @@ export interface SKU {
   referenceId: [{ Value: string }]
   sellers: Seller[]
   images: Image[]
+  attributes?: SkuNonStructuredAttribute[]
 }
 
 export interface SingleSKU extends SKU {


### PR DESCRIPTION
**What is the purpose of this pull request?**

Adds the SkuNonStructuredAttribute interface and an optional attributes? field to the exported SKU interface in react/ProductSummaryTypes.ts.

**What problem is this solving?**

vtex.search-graphql@0.71.0 added SKU.attributes to the GraphQL schema and vtex.store-resources (companion PR) now requests the field via ItemFragment. Without this type update, PLP components that access sku.attributes via useProductSummary() fail TypeScript compilation and block deployment on VTEX IO.
This is part of a set of 3 PRs needed to fully expose non-structured SKU attributes to Store Framework pages:
- vtex.store-resources — requests the field in the shared ItemFragment (https://github.com/vtex-apps/store-resources/pull/198)
- vtex.product-summary-context (this PR) — types the field for PLP components
- vtex.product-context — types the field for PDP components

**How should this be manually tested?**

1. Install vtex.search-graphql@0.71.0, vtex.search-resolver@1.104.0 and the updated vtex.store-resources in a workspace.
2. In a PLP component, access attributes via useProductSummary():

```
tsconst { product } = useProductSummary()
const attributes = product.sku?.attributes
// Expected: array of { id, name, value, visible } — no TypeScript error
```

3. Confirm TypeScript compiles without errors.
4. Confirm components that do not use attributes are unaffected.

**Types of changes**

[ ] Bug fix (a non-breaking change which fixes an issue)
[X] New feature (a non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
[ ] Requires change to documentation, which has been updated accordingly.